### PR TITLE
Fix usage example in documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
 authors = ["Without Boats <woboats@gmail.com>"]
+build = "build.rs"
 description = "Experimental error handling abstraction."
 license = "MIT OR Apache-2.0"
 name = "failure"
 version = "0.0.1"
+
+[build-dependencies]
+skeptic = "0.13"
+
+[dev-dependencies]
+skeptic = "0.13"
 
 [dependencies.backtrace]
 version = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 authors = ["Without Boats <woboats@gmail.com>"]
-build = "build.rs"
 description = "Experimental error handling abstraction."
 license = "MIT OR Apache-2.0"
 name = "failure"
@@ -10,6 +9,7 @@ version = "0.0.1"
 skeptic = "0.13"
 
 [dev-dependencies]
+derive-fail = { path = "derive-fail" }
 skeptic = "0.13"
 
 [dependencies.backtrace]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Example use case:
 ```rust
 #![feature(attr_literals)]
 
-#[macro_use] extern crate fail;
-#[macro_use] extern crate fail_derive;
+#[macro_use] extern crate failure;
+#[macro_use] extern crate derive_fail;
+
+use failure::{Error, Fail};
 
 #[derive(Debug, Fail)]
 #[error_msg("something went wrong {}", message)]
@@ -22,14 +24,21 @@ struct CustomError {
     message: String,
 }
 
+fn run_program() -> Result<(), Error> {
+    Err(CustomError {
+        message: String::from("program failed."),
+    }.into())
+}
+
 fn main() {
     use std::io;
 
-    let err = run_program();
-    match_err!(err => {
-        io::Error:   err    => { println!("IO error: {}", err) }
-        CustomError: err    => { println!("internal error: {}", err) }
-        else:        _      => { panic!("should not have another kind of error") }
-    });
+    if let Err(err) = run_program() {
+        match_err!(err => {
+            io::Error:   err    => { println!("IO error: {}", err) }
+            CustomError: err    => { println!("internal error: {}", err.display()) }
+            else:        _      => { panic!("should not have another kind of error") }
+        })
+    }
 }
 ```

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+extern crate skeptic;
+
+fn main() {
+    // generates doc tests for `README.md`.
+    skeptic::generate_doc_tests(&["README.md"]);
+}

--- a/tests/skeptic.rs
+++ b/tests/skeptic.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
Currently the example code in the `README` does not compile.
That's because of a recent rename of the crate, which will be fixed with this PR.
Also @shepmaster and me added a documentation test based on skeptic to make sure this will never happen again.