### PR TITLE
Provide Error from failure without a backtrace

### DIFF
--- a/src/backtrace/internal.rs
+++ b/src/backtrace/internal.rs
@@ -45,9 +45,7 @@ impl InternalBacktrace {
         }
     }
 
-    pub(super) fn none() -> InternalBacktrace {
-        InternalBacktrace { backtrace: None }
-    }
+    pub(super) const NONE: InternalBacktrace = InternalBacktrace { backtrace: None };
 
     pub(super) fn as_backtrace(&self) -> Option<&Backtrace> {
         let bt = match self.backtrace {

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -98,8 +98,10 @@ with_std! {
             Backtrace { internal: InternalBacktrace::new() }
         }
 
-        pub(crate) fn none() -> Backtrace {
-            Backtrace { internal: InternalBacktrace::none() }
+        pub(crate) const NONE: Backtrace = Backtrace { internal: InternalBacktrace::NONE };
+
+        pub(crate) fn is_none(&self) -> bool {
+            self.internal.as_backtrace().is_none()
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,17 @@ impl<F: Fail> From<F> for Error {
 }
 
 impl Error {
+    /// Creates a new `Error` from `failure` without generating a new backtrace.
+    /// Existing backtraces stored in `failure` will be retained.
+    pub fn from_sans_backtrace<F: Fail>(failure: F) -> Self {
+        Error {
+            inner: Box::new(Inner {
+                backtrace: Backtrace::none(),
+                failure
+            })
+        }
+    }
+
     /// Returns a reference to the underlying cause of this Error. Unlike the
     /// method on `Fail`, this does not return an Option. The Error type
     /// always has an underlying `Fail`ure.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 use core::fmt::{self, Display, Debug};
 
-use core::mem;
-use core::ptr;
-
 use Fail;
 use backtrace::Backtrace;
 use context::Context;
@@ -19,23 +16,60 @@ use compat::Compat;
 /// information, and can be downcast into the `Fail`ure that underlies it for
 /// more detailed inspection.
 pub struct Error {
-    pub(crate) inner: Box<Inner<Fail>>,
+    pub(crate) inner: Box<FailOrWithBacktrace>,
 }
 
-pub(crate) struct Inner<F: ?Sized + Fail> {
+pub(crate) struct WithBacktrace<F: Fail> {
     backtrace: Backtrace,
-    pub(crate) failure: F,
+    failure: F,
+}
+
+static NO_BACKTRACE: &Backtrace = &Backtrace::NONE;
+
+// Unsafe because the `is_withbacktrace` method must be correct for memory safety.
+pub(crate) unsafe trait FailOrWithBacktrace: Send + Sync + 'static {
+    fn fail_ref(&self) -> &Fail;
+    fn fail_mut(&mut self) -> &mut Fail;
+    fn backtrace(&self) -> &Backtrace;
+    fn is_withbacktrace(&self) -> bool;
+}
+
+unsafe impl<T: Fail> FailOrWithBacktrace for T {
+    fn fail_ref(&self) -> &Fail { self }
+    fn fail_mut(&mut self) -> &mut Fail { self }
+    fn backtrace(&self) -> &Backtrace {
+        Fail::backtrace(self).unwrap_or(NO_BACKTRACE)
+    }
+    fn is_withbacktrace(&self) -> bool { false }
+}
+
+unsafe impl<T: Fail> FailOrWithBacktrace for WithBacktrace<T> {
+    fn fail_ref(&self) -> &Fail { &self.failure }
+    fn fail_mut(&mut self) -> &mut Fail { &mut self.failure }
+    fn backtrace(&self) -> &Backtrace {
+        &self.backtrace
+    }
+    fn is_withbacktrace(&self) -> bool { true }
 }
 
 impl<F: Fail> From<F> for Error {
     fn from(failure: F) -> Error {
-        let inner: Inner<F> = {
-            let backtrace = if failure.backtrace().is_none() {
-                Backtrace::new()
-            } else { Backtrace::none() };
-            Inner { failure, backtrace }
+        let inner = if failure.backtrace().is_some() {
+            Box::new(failure)
+        } else {
+            // Attempt to add a backtrace
+            let backtrace = Backtrace::new();
+            if backtrace.is_none() {
+                Box::new(failure) as Box<FailOrWithBacktrace>
+            } else {
+                Box::new(WithBacktrace {
+                    backtrace,
+                    failure,
+                })
+            }
         };
-        Error { inner: Box::new(inner) }
+
+        Error { inner }
     }
 }
 
@@ -44,10 +78,7 @@ impl Error {
     /// Existing backtraces stored in `failure` will be retained.
     pub fn from_sans_backtrace<F: Fail>(failure: F) -> Self {
         Error {
-            inner: Box::new(Inner {
-                backtrace: Backtrace::none(),
-                failure
-            })
+            inner: Box::new(failure)
         }
     }
 
@@ -55,7 +86,7 @@ impl Error {
     /// method on `Fail`, this does not return an Option. The Error type
     /// always has an underlying `Fail`ure.
     pub fn cause(&self) -> &Fail {
-        &self.inner.failure
+        self.inner.fail_ref()
     }
 
     /// Get a reference to the Backtrace for this Error.
@@ -64,7 +95,7 @@ impl Error {
     /// be returned. Otherwise, the backtrace will have been constructed at
     /// the point that failure was cast into the Error type.
     pub fn backtrace(&self) -> &Backtrace {
-        self.inner.failure.backtrace().unwrap_or(&self.inner.backtrace)
+        self.inner.backtrace()
     }
 
     /// Provide context for this Error.
@@ -100,21 +131,19 @@ impl Error {
     /// the case that the underlying error is of a different type, the
     /// original Error is returned.
     pub fn downcast<T: Fail>(self) -> Result<T, Error> {
-        let ret: Option<T> = self.downcast_ref().map(|fail| {
-            unsafe {
-                // drop the backtrace
-                let _ = ptr::read(&self.inner.backtrace as *const Backtrace);
-                // read out the fail type
-                ptr::read(fail as *const T)
-            }
-        });
-        match ret {
-            Some(ret) => {
-                // forget self (backtrace is dropped, failure is moved
-                mem::forget(self);
-                Ok(ret)
-            }
-            _       => Err(self)
+        if self.downcast_ref::<T>().is_some() {
+            Ok(unsafe {
+                let is_withbacktrace = self.inner.is_withbacktrace();
+                let ptr: *mut FailOrWithBacktrace = Box::into_raw(self.inner);
+
+                if is_withbacktrace {
+                    Box::from_raw(ptr as *mut WithBacktrace<T>).failure
+                } else {
+                    *Box::from_raw(ptr as *mut T)
+                }
+            })
+        } else {
+            Err(self)
         }
     }
 
@@ -123,7 +152,7 @@ impl Error {
     ///
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_ref<T: Fail>(&self) -> Option<&T> {
-        self.inner.failure.downcast_ref()
+        self.inner.fail_ref().downcast_ref::<T>()
     }
 
     /// Attempt to downcast this Error to a particular `Fail` type by
@@ -131,25 +160,24 @@ impl Error {
     ///
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_mut<T: Fail>(&mut self) -> Option<&mut T> {
-        self.inner.failure.downcast_mut()
+        self.inner.fail_mut().downcast_mut::<T>()
     }
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.inner.failure, f)
-    }
-}
-
-impl Debug for Inner<Fail> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Error {{ failure: {:?} }}\n\n{:?}", &self.failure, &self.backtrace)
+        Display::fmt(&self.cause(), f)
     }
 }
 
 impl Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", &self.inner)
+        write!(f, "Error {{ failure: {:?} }}\n\n", self.inner.fail_ref())?;
+        let backtrace = self.inner.backtrace();
+        if !backtrace.is_none() {
+            write!(f, "{:?}", backtrace)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
In certain scenarios it can be too much of a performance cost to create
a backtrace, but it's still nice to provide a centralized error type.

Totally open to bikeshedding about the name-- `sans` sounds a bit funny, but `from_without_backtrace` is wrong since it doesn't get rid of an existing backtrace, and `from_without_creating_backtrace` is a bit too on-the-nose :smile: 