### PR TITLE
add note about how to create a Backtrace

### DIFF
--- a/book/src/derive-fail.md
+++ b/book/src/derive-fail.md
@@ -145,6 +145,8 @@ This happens automatically; no other annotations are necessary. It only works
 if the type is named Backtrace, and not if you have created an alias for the
 Backtrace type.
 
+To initialize the field, simply call `Backtrace::new()` when constructing your error.
+
 ## Overriding `cause`
 
 In contrast to `backtrace`, the cause cannot be determined by type name alone


### PR DESCRIPTION
Maybe this is obvious, but I went to the API docs to look for it. I somehow thought it would be automatic.

More broadly, with my `error-chain`-colored glasses I don't really understand the design decision to put backtraces in some errors and not others, and making you construct them manually. That, along with the specialization issue, seems like it'll encourage libraries *not* to include backtraces, which is bad for debugging. If backtraces are zero-sized when disabled, what's the harm of including them everywhere?