### PR TITLE
Rename '`Fail`ure' to 'failure' in documentation

### DIFF
--- a/book/src/derive-fail.md
+++ b/book/src/derive-fail.md
@@ -72,7 +72,7 @@ perform method calls or use other arbitrary expressions.
 With regular structs, you can use the name of the field in string
 interpolation. When deriving Fail for a tuple struct, you might expect to use
 the numeric index to refer to fields `0`, `1`, et cetera. However, a compiler
-limitation prevents this from parsing today. 
+limitation prevents this from parsing today.
 
 For the time being, tuple field accesses in the display attribute need to be
 prefixed with an underscore:

--- a/book/src/derive-fail.md
+++ b/book/src/derive-fail.md
@@ -22,7 +22,7 @@ impl fmt::Display for MyError {
 }
 ```
 
-All `Fail`ures need to implement `Display`, so we have added an impl of
+All failures need to implement `Display`, so we have added an impl of
 Display. However, implementing `Display` is much more boilerplate than
 implementing `Fail` - this is why we support deriving `Display` for you.
 

--- a/book/src/error.md
+++ b/book/src/error.md
@@ -37,13 +37,13 @@ return Options - an Error is *guaranteed* to have a cause and a backtrace.
 println!("{}, {}", error.cause(), error.backtrace())
 ```
 
-An `Error`'s cause is always the `Fail`ure that was cast into this `Error`.
-That `Fail`ure may have further underlying causes. Unlike Fail, this means that
+An `Error`'s cause is always the failure that was cast into this `Error`.
+That failure may have further underlying causes. Unlike Fail, this means that
 the cause of an Error will have the same Display representation as the Error
 itself.
 
 As to the error's guaranteed backtrace, when the conversion into the Error type
-happens, if the underlying `Fail`ure does not provide a backtrace, a new
+happens, if the underlying failure does not provide a backtrace, a new
 backtrace is constructed pointing to that conversion point (rather than the
 origin of the error). This construction only happens if there is no underlying
 backtrace; if it does have a backtrace no new backtrace is constructed.
@@ -64,7 +64,7 @@ match error.downcast::<io::Error>() {
 ## Implementation details
 
 `Error` is essentially a trait object, but with some fanciness to store the
-backtrace it may generate if the underlying `Fail`ure did not have one. In
+backtrace it may generate if the underlying failure did not have one. In
 particular, we use a custom dynamically sized type to store the backtrace
 information inline with the trait object data.
 

--- a/book/src/fail.md
+++ b/book/src/fail.md
@@ -3,10 +3,10 @@
 The `Fail` trait is a replacement for [`std::error::Error`][stderror]. It has
 been designed to support a number of operations:
 
-- Because it is bound by both `Debug` and `Display`, any `Fail`ure can be
+- Because it is bound by both `Debug` and `Display`, any failure can be
   printed in two ways.
 - It has both a `backtrace` and a `cause` method, allowing users to get
-- It supports wrapping `Fail`ures in additional contextual information.
+- It supports wrapping failures in additional contextual information.
 - Because it is bound by `Send` and `Sync`, failures can be moved and share
   between threads easily.
 - Because it is bound by `'static`, the abstract `Fail` trait object can be
@@ -16,6 +16,8 @@ Every new error type in your code should implement Fail, so it can be
 integrated into the entire system built around this trait. You can manually
 implement `Fail` yourself, or you can use the [derive][derive] for Fail defined
 in a separate crate and documented [here][derive-docs].
+
+Implementors of this trait are called 'failures'.
 
 ## Cause
 
@@ -41,7 +43,7 @@ while let Some(cause) = fail.cause() {
 ```
 
 Because `&Fail` supports downcasting, you can also inspect causes in more
-detail if you are expecting a certain `Fail`ure:
+detail if you are expecting a certain failure:
 
 ```rust
 while let Some(cause) = fail.cause() {
@@ -60,7 +62,7 @@ while let Some(cause) = fail.cause() {
 
 Errors can also generate a backtrace when they are constructed, helping you
 determine the place the error was generated and every function that called into
-that. Like causes, this is entirely optional - the authors of each `Fail`ure
+that. Like causes, this is entirely optional - the authors of each failure
 have to decide of generating a backtrace is appropriate in their use case.
 
 The backtrace method allows all errors to expose their backtrace if they have

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -17,7 +17,7 @@ without_std! {
     ///   printing it). If the Backtrace is never used for anything, symbols
     ///   never get resolved.
     ///
-    /// Even with these optimizations, including a backtrace in your `Fail`ure
+    /// Even with these optimizations, including a backtrace in your failure
     /// may not be appropriate to your use case. You are not required to put a
     /// backtrace in a custom `Fail` type.
     ///
@@ -83,7 +83,7 @@ with_std! {
     ///   printing it). If the Backtrace is never used for anything, symbols
     ///   never get resolved.
     ///
-    /// Even with these optimizations, including a backtrace in your `Fail`ure
+    /// Even with these optimizations, including a backtrace in your failure
     /// may not be appropriate to your use case. You are not required to put a
     /// backtrace in a custom `Fail` type.
     pub struct Backtrace {

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,15 +8,15 @@ use backtrace::Backtrace;
 use context::Context;
 use compat::Compat;
 
-/// The `Error` type, which can contain any `Fail`ure.
+/// The `Error` type, which can contain any failure.
 ///
 /// Functions which accumulate many kinds of errors should return this type.
-/// All `Fail`ures can be converted into it, so functions which catch those
+/// All failures can be converted into it, so functions which catch those
 /// errors can be tried with `?` inside of a function that returns this kind
 /// of Error.
 ///
 /// In addition to implementing Debug and Display, this type carries Backtrace
-/// information, and can be downcast into the `Fail`ure that underlies it for
+/// information, and can be downcast into the failure that underlies it for
 /// more detailed inspection.
 pub struct Error {
     pub(crate) inner: Box<Inner<Fail>>,
@@ -42,7 +42,7 @@ impl<F: Fail> From<F> for Error {
 impl Error {
     /// Returns a reference to the underlying cause of this Error. Unlike the
     /// method on `Fail`, this does not return an Option. The Error type
-    /// always has an underlying `Fail`ure.
+    /// always has an underlying failure.
     pub fn cause(&self) -> &Fail {
         &self.inner.failure
     }
@@ -67,7 +67,7 @@ impl Error {
     ///
     /// This takes any type that implements Display, as well as
     /// Send/Sync/'static. In practice, this means it can take a String or a
-    /// string literal, or a `Fail`ure, or some other custom context
+    /// string literal, or a failure, or some other custom context
     /// carrying type.
     pub fn context<D: Display + Send + Sync + 'static>(self, context: D) -> Context<D> {
         Context::with_err(context, self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ with_std! {
 
 /// The `Fail` trait.
 ///
+/// Implementors of this trait are called 'failures'.
+///
 /// All error types should implement `Fail`, which provides a baseline of
 /// functionality that they all share.
 ///
@@ -57,41 +59,41 @@ with_std! {
 /// - `Send + Sync`: Your error type is required to be safe to transfer to and
 ///   reference from another thread
 ///
-/// Additionally, all `Fail`ures must be `'static`. This enables downcasting.
+/// Additionally, all failures must be `'static`. This enables downcasting.
 ///
 /// `Fail` provides several methods with default implementations. Two of these
 /// may be appropriate to override depending on the definition of your
-/// particular `Fail`ure: the `cause` and `backtrace` methods.
+/// particular failure: the `cause` and `backtrace` methods.
 ///
 /// The `derive-fail` crate provides a way to derive the `Fail` trait for your
 /// type. Additionally, all types that already implement `std::error::Error`,
 /// and are also `Send`, `Sync`, and `'static`, implement `Fail` by a blanket
 /// impl.
 pub trait Fail: Display + Debug + Send + Sync + 'static {
-    /// Returns a reference to the underlying cause of this `Fail`ure, if it
+    /// Returns a reference to the underlying cause of this failure, if it
     /// is an error that wraps other errors.
     ///
-    /// Returns `None` if this `Fail`ure does not have another error as its
+    /// Returns `None` if this failure does not have another error as its
     /// underlying cause. By default, this returns `None`.
     ///
     /// This should **never** return a reference to self, but only return
-    /// `Some` when it can return a **different* `Fail`ure. Users may loop
+    /// `Some` when it can return a **different* failure. Users may loop
     /// loop the cause chain, and returning self would result in an infinite
     /// loop.
     fn cause(&self) -> Option<&Fail> {
         None
     }
 
-    /// Returns a reference to the Backtrace carried by this `Fail`ure, if it
+    /// Returns a reference to the Backtrace carried by this failure, if it
     /// carries one.
     ///
-    /// Returns `None` if this `Fail`ure does not carry a backtrace. By 
+    /// Returns `None` if this failure does not carry a backtrace. By
     /// default, this returns `None`.
     fn backtrace(&self) -> Option<&Backtrace> {
         None
     }
 
-    /// Provide context for this `Fail`ure.
+    /// Provide context for this failure.
     ///
     /// This can provide additional information about this error, appropriate
     /// to the semantics of the current layer. That is, if you have a lower
@@ -102,7 +104,7 @@ pub trait Fail: Display + Debug + Send + Sync + 'static {
     ///
     /// This takes any type that implements Display, as well as
     /// Send/Sync/'static. In practice, this means it can take a String or a
-    /// string literal, or another `Fail`ure, or some other custom context
+    /// string literal, or another failure, or some other custom context
     /// carrying type.
     fn context<D>(self, context: D) -> Context<D> where
         D: Display + Send + Sync + 'static,
@@ -111,10 +113,10 @@ pub trait Fail: Display + Debug + Send + Sync + 'static {
         Context::with_err(context, self)
     }
 
-    /// Wrap this `Fail`ure in a compatibility wrapper that implements
+    /// Wrap this failure in a compatibility wrapper that implements
     /// `std::error::Error`.
     ///
-    /// This allows `Fail`ures  to be compatible with older crates that
+    /// This allows failures  to be compatible with older crates that
     /// expect types that implement the `Error` trait from `std::error`.
     fn compat(self) -> Compat<Self> where Self: Sized {
         Compat { error: self }
@@ -127,7 +129,7 @@ pub trait Fail: Display + Debug + Send + Sync + 'static {
 }
 
 impl Fail {
-    /// Attempt to downcast this `Fail`ure to a concrete type by reference.
+    /// Attempt to downcast this failure to a concrete type by reference.
     ///
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_ref<T: Fail>(&self) -> Option<&T> {
@@ -138,7 +140,7 @@ impl Fail {
         }
     }
 
-    /// Attempt to downcast this `Fail`ure to a concrete type by mutable
+    /// Attempt to downcast this failure to a concrete type by mutable
     /// reference.
     ///
     /// If the underlying error is not of type `T`, this will return `None`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! An experimental new error handling library.
-//! 
+//!
 //! The primary items exported by this library are:
 //!
 //! - `Fail`: a new trait for custom error types in Rust.
@@ -50,7 +50,7 @@ with_std! {
 ///
 /// `Fail` has no required methods, but it does require that your type
 /// implement several other traits:
-/// 
+///
 /// - `Display`: to print a user-friendly representation of the error.
 /// - `Debug`: to print a verbose, developer-focused representation of the
 ///   error.


### PR DESCRIPTION
Rename '`Fail`ure' to 'failure' in documentation.