### PR TITLE
Changes to error message module.

### DIFF
--- a/src/error_message.rs
+++ b/src/error_message.rs
@@ -1,20 +1,21 @@
 use core::fmt::{self, Display, Debug};
 
 use Fail;
+use Error;
 
 /// Construct a `Fail` type from a string.
 ///
 /// This is a convenient way to turn a string into an error value that
 /// can be passed around, if you do not want to create a new `Fail` type for
 /// this use case.
-pub fn err_msg<T, D: Display + Debug + Sync + Send + 'static>(msg: D) -> Result<T, ErrorMessage<D>> {
-    Err(ErrorMessage { msg })
+pub fn err_msg<D: Display + Debug + Sync + Send + 'static>(msg: D) -> Error {
+    Error::from(ErrorMessage { msg })
 }
 
 /// A Fail type that just contains an error message. You can construct
 /// this from the `err_msg` function.
 #[derive(Debug)]
-pub struct ErrorMessage<D: Display + Debug + Sync + Send + 'static> {
+struct ErrorMessage<D: Display + Debug + Sync + Send + 'static> {
     msg: D,
 }
 
@@ -26,15 +27,14 @@ impl<D: Display + Debug + Sync + Send + 'static> Display for ErrorMessage<D> {
     }
 }
 
-/// Construct an ErrorMessage type using the standard string
-/// interpolation syntax.
+/// Construct an Error using the standard string interpolation syntax.
 ///
 /// ```rust
 /// #[macro_use] extern crate failure;
 ///
 /// fn main() {
 ///     let code = 101;
-///     let err: Result<(), _> = format_err!("Error code: {}", code);
+///     let err = format_err!("Error code: {}", code);
 /// }
 /// ```
 #[macro_export]

--- a/src/error_message.rs
+++ b/src/error_message.rs
@@ -7,12 +7,12 @@ use Fail;
 /// This is a convenient way to turn a string into an error value that
 /// can be passed around, if you do not want to create a new `Fail` type for
 /// this use case.
-pub fn error_msg<D: Display + Debug + Sync + Send + 'static>(msg: D) -> ErrorMessage<D> {
-    ErrorMessage { msg }
+pub fn err_msg<T, D: Display + Debug + Sync + Send + 'static>(msg: D) -> Result<T, ErrorMessage<D>> {
+    Err(ErrorMessage { msg })
 }
 
 /// A Fail type that just contains an error message. You can construct
-/// this from the `error_msg` function.
+/// this from the `err_msg` function.
 #[derive(Debug)]
 pub struct ErrorMessage<D: Display + Debug + Sync + Send + 'static> {
     msg: D,
@@ -34,10 +34,10 @@ impl<D: Display + Debug + Sync + Send + 'static> Display for ErrorMessage<D> {
 ///
 /// fn main() {
 ///     let code = 101;
-///     let err = format_err!("Error code: {}", code);
+///     let err: Result<(), _> = format_err!("Error code: {}", code);
 /// }
 /// ```
 #[macro_export]
 macro_rules! format_err {
-    ($($arg:tt)*) => { $crate::error_msg(format!($($arg)*)) }
+    ($($arg:tt)*) => { $crate::err_msg(format!($($arg)*)) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use core::fmt::{Display, Debug};
 pub use backtrace::Backtrace;
 pub use compat::Compat;
 pub use context::Context;
-pub use error_message::{ErrorMessage, error_msg};
+pub use error_message::{ErrorMessage, err_msg};
 pub use result_ext::ResultExt;
 
 with_std! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use core::fmt::{Display, Debug};
 pub use backtrace::Backtrace;
 pub use compat::Compat;
 pub use context::Context;
-pub use error_message::{ErrorMessage, err_msg};
+pub use error_message::err_msg;
 pub use result_ext::ResultExt;
 
 with_std! {


### PR DESCRIPTION
- `error_msg` => `err_msg`
- `err_msg` returns a Result.

This may require annoying type annotations at times, but it
also allows a direct `return` of `err_msg` and `format_err!`
without having to wrap them in `Err`.