### PR TITLE
Add Iterator over causes of a `Fail`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use core::fmt::{self, Display, Debug};
 use core::mem;
 use core::ptr;
 
-use Fail;
+use {Causes, Fail};
 use backtrace::Backtrace;
 use context::Context;
 use compat::Compat;
@@ -127,6 +127,14 @@ impl Error {
     /// If the underlying error is not of type `T`, this will return `None`.
     pub fn downcast_mut<T: Fail>(&mut self) -> Option<&mut T> {
         self.inner.failure.downcast_mut()
+    }
+
+    /// Returns a iterator over the causes of the `Error`.
+    ///
+    /// The returned iterator does not include the `Error` it self as
+    /// the first item
+    pub fn causes(&self) -> Causes {
+        Causes { fail: Some(self.cause()) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,34 +175,27 @@ impl Fail {
         find_root_cause(self)
     }
 
-    /// Returns a iterator over the causes of this `Fail`
-    pub fn causes(&self) -> CauseIter {
-        CauseIter { fail: self }
+    /// Returns a iterator over the causes of this `Fail` with it self
+    /// as the first item
+    pub fn causes(&self) -> Causes {
+        Causes { fail: Some(self) }
     }
 }
 
 #[cfg(feature = "std")]
 impl<E: StdError + Send + Sync + 'static> Fail for E { }
 
-impl<'f> IntoIterator for &'f Fail {
-    type IntoIter = CauseIter<'f>;
-    type Item = &'f Fail;
-    fn into_iter(self) -> CauseIter<'f> {
-        self.causes()
-    }
-}
-
 /// A iterator over the causes of a `Fail`
-pub struct CauseIter<'f> {
-    fail: &'f Fail,
+pub struct Causes<'f> {
+    fail: Option<&'f Fail>,
 }
 
-impl<'f> Iterator for CauseIter<'f> {
+impl<'f> Iterator for Causes<'f> {
     type Item = &'f Fail;
     fn next(&mut self) -> Option<&'f Fail> {
-        self.fail.cause().map(|cause| {
-            self.fail = cause;
-            cause
+        self.fail.map(|fail| {
+            self.fail = fail.cause();
+            fail
         })
     }
 }


### PR DESCRIPTION
this way you can look if a `Fail` contains e.g. an io::Error like this

```rust
if let Some(io_err) fail.causes().filter_map(Fail::downcast_ref::<io::Error>).next() {
    println!("we got an io::Error: {}" , io_err)
}
```
or even

```rust
impl Fail
    /// Returns the first apperence of a `Fail` ot type `F` in the chain of causes
    pub fn contains<F: Fail>(&self) -> Option<&F> {
        if let Some(fail) = self.downcast_ref::<F>() {
            Some(fail)
        } else {
            self.causes().filter_map(Fail::downcast_ref::<F>).next()
            
        }
    }
}
```