### PR TITLE
Add bail! and ensure! macros

### DIFF
--- a/examples/bail_ensure.rs
+++ b/examples/bail_ensure.rs
@@ -1,0 +1,26 @@
+#[macro_use]
+extern crate failure;
+
+use failure::Error;
+
+fn bailer() -> Result<(), Error> {
+    // bail!("ruh roh");
+    bail!("ruh {}", "roh");
+}
+
+fn ensures() -> Result<(), Error> {
+    ensure!(true, "true is false");
+    ensure!(false, "false is false");
+    Ok(())
+}
+
+fn main() {
+    match bailer() {
+        Ok(_) => println!("ok"),
+        Err(e) => println!("{}", e),
+    }
+    match ensures() {
+        Ok(_) => println!("ok"),
+        Err(e) => println!("{}", e),
+    }
+}


### PR DESCRIPTION
PR for #72. I copied and adapted the macros from error_chain. I used the ` err_msg` function, which means that anything that works for `err_msg` will also work. Editor did some unintended formatting also.