### PR TITLE
Support re-exporting derive from failure.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,22 @@
 [package]
 authors = ["Without Boats <boats@mozilla.com>"]
 description = "Experimental error handling abstraction."
-license = "MIT OR Apache-2.0"
-name = "failure"
-version = "0.1.0"
-repository = "https://github.com/withoutboats/failure"
 documentation = "https://docs.rs/failure"
 homepage = "https://boats.gitlab.io/failure"
+license = "MIT OR Apache-2.0"
+name = "failure"
+repository = "https://github.com/withoutboats/failure"
+version = "0.1.1"
+
+[dependencies.failure_derive]
+optional = true
+version = "0.1.1"
 
 [dependencies.backtrace]
-version = "0.3.3"
 optional = true
+version = "0.3.3"
 
 [features]
-default = ["std"]
+default = ["std", "derive"]
 std = ["backtrace"]
+derive = ["failure_derive"]

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ learned from experience with quick-error and error-chain.
 ## Example
 
 ```rust
-extern crate failure;
 extern crate serde;
 extern crate toml;
 
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 #[macro_use] extern crate serde_derive;
 
 use std::collections::HashMap;

--- a/book/src/custom-fail.md
+++ b/book/src/custom-fail.md
@@ -10,8 +10,8 @@ this context.
 3. Callers can destructure your error without any sort of downcasting.
 
 To implement this pattern, you should define your own type that implements
-`Fail`. You can use the [custom derive][derive-fail] provided in failure_derive
-to make this easier. For example:
+`Fail`. You can use the [custom derive][derive-fail] to make this easier. For
+example:
 
 ```rust
 #[derive(Fail, Debug)]

--- a/book/src/derive-fail.md
+++ b/book/src/derive-fail.md
@@ -1,14 +1,17 @@
 # Deriving `Fail`
 
 Though you can implement `Fail` yourself, we also provide a derive macro to
-generate the impl for you. This macro is provided through the `failure_derive`
-crate.
+generate the impl for you. To get access to this macro, you must tag the extenr
+crate declaration with `#[macro_use]`, as in:
+
+```rust
+#[macro_use] extern crate failure;
+```
 
 In its smallest form, deriving Fail looks like this:
 
 ```rust
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 use std::fmt;
 
@@ -31,8 +34,7 @@ implementing `Fail` - this is why we support deriving `Display` for you.
 You can derive an implementation of `Display` with a special attribute:
 
 ```rust
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 #[derive(Fail, Debug)]
 #[fail(display = "An error occurred.")]
@@ -50,8 +52,7 @@ do this with failure using the same string interpolation syntax as Rust's
 formatting and printing macros:
 
 ```rust
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 #[derive(Fail, Debug)]
 #[fail(display = "An error occurred with error code {}. ({})", code, message)]
@@ -78,8 +79,7 @@ For the time being, tuple field accesses in the display attribute need to be
 prefixed with an underscore:
 
 ```rust
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 #[derive(Fail, Debug)]
 #[fail(display = "An error occurred with error code {}.", _0)]
@@ -98,8 +98,7 @@ each variant of the enum, rather than to the enum as a whole. The Display impl
 will match over the enum to generate the correct error message. For example:
 
 ```rust
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 #[derive(Fail, Debug)]
 enum MyError {
@@ -118,8 +117,7 @@ The backtrace method will be automatically overridden if the type contains a
 field with the type `Backtrace`. This works for both structs and enums.
 
 ```rust
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 use failure::Backtrace;
 
@@ -156,9 +154,7 @@ This can be used in fields of enums as well as structs.
 
 
 ```rust
-#[derive(Fail, Debug)]
-extern crate failure;
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 
 use std::io;
 

--- a/book/src/fail.md
+++ b/book/src/fail.md
@@ -15,7 +15,7 @@ been designed to support a number of operations:
 
 Every new error type in your code should implement Fail, so it can be
 integrated into the entire system built around this trait. You can manually
-implement `Fail` yourself, or you can use the [derive][derive] for Fail defined
+implement `Fail` yourself, or you can use the derive for Fail defined
 in a separate crate and documented [here][derive-docs].
 
 Implementors of this trait are called 'failures'.
@@ -136,6 +136,5 @@ The biggest hole in our backwards compatibility story is that you cannot
 implement `std::error::Error` and also override the backtrace and cause methods
 on `Fail`. We intend to enable this with specialization when it becomes stable.
 
-[derive]: https://github.com/withoutboats/failure_derive
 [derive-docs]: https://boats.gitlab.io/failure/derive-fail.html
 [stderror]: https://doc.rust-lang.org/std/error/trait.Error.html

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -12,11 +12,10 @@ creating and managing errors in Rust. Additional documentation is found here:
 [derive-repo]: https://github.com/withoutboats/failure_derive
 
 ```rust
-extern crate failure;
 extern crate serde;
 extern crate toml;
 
-#[macro_use] extern crate failure_derive;
+#[macro_use] extern crate failure;
 #[macro_use] extern crate serde_derive;
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@ pub use compat::Compat;
 pub use context::Context;
 pub use result_ext::ResultExt;
 
+#[cfg(feature = "derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate failure_derive;
+
+#[cfg(feature = "derive")]
+#[doc(hidden)]
+pub use failure_derive::*;
+
 with_std! {
     extern crate core;
 


### PR DESCRIPTION
Closes #71.

Users will get the derive from failure by default. You can turn off this feature though. Most users though can just write:

```toml
[dependencies]
failure = "0.1.1"
```
```rust
#[macro_use] extern crate failure;
```

no_std users will not be able to get the derive from failure, because they need to turn off the std feature in the derive as well. They should do:

```toml
[dependencies.failure]
version = "0.1.1"
default-features = false

[dependencies.failure_derive]
version = "0.1.1"
default-features = false
```
```rust
extern crate failure;
#[macro_use] extern crate failure_derive;
```

TODO:
- [x] update examples to match this