### PR TITLE
Fix bail!() to be more similar to error-chain

### DIFF
--- a/examples/bail_ensure.rs
+++ b/examples/bail_ensure.rs
@@ -3,14 +3,22 @@ extern crate failure;
 
 use failure::Error;
 
+#[derive(Debug, Fail)]
+#[fail(display = "My error!")]
+struct MyError;
+
 fn bailer() -> Result<(), Error> {
     // bail!("ruh roh");
     bail!("ruh {}", "roh");
 }
 
+fn my_bailer() -> Result<(), Error> {
+    bail!(MyError);
+}
+
 fn ensures() -> Result<(), Error> {
-    ensure!(true, "true is false");
-    ensure!(false, "false is false");
+    ensure!(true, failure::err_msg("true is false"));
+    ensure!(false, failure::err_msg("false is false"));
     Ok(())
 }
 
@@ -22,5 +30,14 @@ fn main() {
     match ensures() {
         Ok(_) => println!("ok"),
         Err(e) => println!("{}", e),
+    }
+    match my_bailer() {
+        Ok(_) => println!("ok"),
+        Err(e) => {
+            match e.downcast::<MyError>() {
+                Ok(err) => println!("My error! {}", err),
+                Err(bad) => println!("Some other error? {:?}", bad),
+            }
+        }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,7 +9,7 @@
 #[macro_export]
 macro_rules! bail {
     ($e:expr) => {
-        return Err($crate::err_msg($e));
+        return Err(From::from($e));
     };
     ($fmt:expr, $($arg:tt)+) => {
         return Err($crate::err_msg(format!($fmt, $($arg)+)));


### PR DESCRIPTION
This changes the `bail!()` macro such that if it's passed one parameter,
it's expected to be of a type that can be converted to the correct
error type with From. Otherwise, if it has multiple parameters,
they're treated as a format string an its parameters.

Unfortunately this means that if its passed a single string, it will
not work as expected because a string can't convert directly to an error
type - it requires the use of `failure::err_msg()` to format the string.
This differs from error-chain as it has From conversion from string types
to an Error type.

(It would be nice to fix this.)

Addresses https://github.com/withoutboats/failure/issues/94