### PR TITLE
Implement Fail for Box<Fail>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,16 @@ impl Fail {
 #[cfg(feature = "std")]
 impl<E: StdError + Send + Sync + 'static> Fail for E {}
 
+impl Fail for Box<Fail> {
+    fn cause(&self) -> Option<&Fail> {
+        (**self).cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        (**self).backtrace()
+    }
+}
+
 /// A iterator over the causes of a `Fail`
 pub struct Causes<'f> {
     fail: Option<&'f Fail>,


### PR DESCRIPTION
This is related to https://github.com/withoutboats/failure_derive/pull/6, and adds an implementation of Fail for Box<Fail>.

This means that you can mark a `Box<Fail>` member of a struct as `#[cause]`.