### PR TITLE
Test --no-default-features as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rust:
     - beta
     - nightly
 cache: cargo
+script:
+- cargo test
+- cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,8 @@ version = "0.3.3"
 default = ["std", "derive"]
 std = ["backtrace"]
 derive = ["failure_derive"]
+
+[[example]]
+name = "bail_ensure"
+path = "./examples/bail_ensure.rs"
+required-features = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,7 @@ impl Fail {
 #[cfg(feature = "std")]
 impl<E: StdError + Send + Sync + 'static> Fail for E {}
 
+#[cfg(feature = "std")]
 impl Fail for Box<Fail> {
     fn cause(&self) -> Option<&Fail> {
         (**self).cause()


### PR DESCRIPTION
Closes #30 
Closes #114 

This sets travis's test script to do both `cargo test` and `cargo test --no-default-features`.

Note: The matrix is still size 4 (compile on 1.18.0, stable, beta, and nightly).
This just means that each member of the matrix does (effectively) `cargo test && cargo test --no-default-features` instead of just `cargo test`.

The `--no-default-features` build only recompiles failure and not any of the dependencies, so it shouldn't break the cache.