### PR TITLE
An error that puzzles me - can you help?

### DIFF
--- a/examples/downcast_causes.rs
+++ b/examples/downcast_causes.rs
@@ -1,0 +1,12 @@
+extern crate failure;
+
+use failure::{err_msg, Fail, Error};
+
+pub fn first_cause_of_type<T: Fail>(root: &Error) -> Option<&T> {
+    root.causes().filter_map(|c| c.downcast_ref::<T>()).next()
+}
+
+fn main() {
+    let err = Error::from(err_msg("hi"));
+    first_cause_of_type::<Error>(&err);
+}


### PR DESCRIPTION
Maybe you can make this compile - I can't figure it out.
This should reproduce the issue for you: `cargo build --example downcast_causes`.

I think it's clear what the code tries to achieve, but I wonder
why it is not working, giving the following error message:

```
Compiling failure v0.1.1 (file:///Users/byron/dev/failure)
error[E0277]: the trait bound `failure::Error: std::error::Error` is not satisfied
  --> examples/downcast_causes.rs:11:5
   |
11 |     first_cause_of_type::<Error>(&err);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `failure::Error`
   |
   = note: required because of the requirements on the impl of `failure::Fail` for `failure::Error`
   = note: required by `first_cause_of_type`

error: aborting due to previous error

error: Could not compile `failure`.

To learn more, run the command again with --verbose.
```