### PR TITLE
Split backtrace and std features up.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ cache: cargo
 script:
 - cargo test
 - cargo test --no-default-features
+- cargo test --no-default-features --features std
+- cargo test --no-default-features --features backtrace

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ optional = true
 version = "0.3.3"
 
 [features]
-default = ["std", "derive"]
-std = ["backtrace"]
+default = ["std", "derive", "backtrace"]
+std = []
 derive = ["failure_derive"]
 
 [[example]]

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -40,14 +40,14 @@ without_backtrace! {
             Backtrace { _secret: () }
         }
 
-        with_backtrace! {
-            pub(crate) fn none() -> Backtrace {
-                Backtrace { _secret: () }
-            }
+        #[cfg(feature = "std")]
+        pub(crate) fn none() -> Backtrace {
+            Backtrace { _secret: () }
+        }
 
-            pub(crate) fn is_none(&self) -> bool {
-                true
-            }
+        #[cfg(feature = "std")]
+        pub(crate) fn is_none(&self) -> bool {
+            true
         }
     }
 

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -1,6 +1,6 @@
 use core::fmt::{self, Debug, Display};
 
-without_std! {
+without_backtrace! {
     /// A `Backtrace`.
     ///
     /// This is an opaque wrapper around the backtrace provided by
@@ -39,6 +39,16 @@ without_std! {
         pub fn new() -> Backtrace {
             Backtrace { _secret: () }
         }
+
+        with_backtrace! {
+            pub(crate) fn none() -> Backtrace {
+                Backtrace { _secret: () }
+            }
+
+            pub(crate) fn is_none(&self) -> bool {
+                true
+            }
+        }
     }
 
     impl Default for Backtrace {
@@ -60,7 +70,7 @@ without_std! {
     }
 }
 
-with_std! {
+with_backtrace! {
     extern crate backtrace;
 
     mod internal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,12 @@
 
 macro_rules! with_std { ($($i:item)*) => ($(#[cfg(feature = "std")]$i)*) }
 macro_rules! without_std { ($($i:item)*) => ($(#[cfg(not(feature = "std"))]$i)*) }
+macro_rules! with_backtrace {
+    ($($i:item)*) => ($(#[cfg(all(feature = "backtrace", feature = "std"))]$i)*)
+}
+macro_rules! without_backtrace {
+    ($($i:item)*) => ($(#[cfg(any(not(feature = "backtrace"), not(feature = "std")))]$i)*)
+}
 
 mod backtrace;
 mod compat;


### PR DESCRIPTION
This allows depending on std Fail implementations without depending on the backtrace crate.

There are two caveats. First, in this PR both `backtrace` and `std` must be enabled in order for someone to use the backtrace functionality. Second, this might be a breaking change if someone depended on `default-features = false, features = ["std"]` in the past, and relied on std depending on backtrace to bring it in.

This changes the travis CI configuration to test with std and backtrace enabled separately so as to ensure correctness.

Closes #127.