### PR TITLE
Show the inner error in the Debug implementation of SyncFailure

### DIFF
--- a/src/sync_failure.rs
+++ b/src/sync_failure.rs
@@ -90,7 +90,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.inner.lock().unwrap().fmt(f)
+        (*self.inner.lock().unwrap()).fmt(f)
     }
 }
 


### PR DESCRIPTION
Otherwise, the Debug implementation for SyncFailure will always print:

`MutexGuard { lock: Mutex { data: <locked> } }`

This same pattern applies to the Display impl of SyncFailure, but using the Display impl of MutexGuard just forwards to the Display impl of the inner locked data, so this is fine.

I'm not 100% sure why the Debug impl of MutexGuard is so unhelpful, but it seems wrong for SyncFailure to propagate this unhelpfulness.