### PR TITLE
Fix the bail! macro.

### DIFF
--- a/failure-1.X/src/macros.rs
+++ b/failure-1.X/src/macros.rs
@@ -1,26 +1,73 @@
-/// Exits a function early with an `Error`.
+/// "Throw" an error, returning it early.
+/// 
+/// Like the `?` operator, this performs a conversion into the return type of
+/// the function you are early returning from.
+/// 
+/// ```
+/// #[macro_use] extern crate failure;
 ///
-/// The `bail!` macro provides an easy way to exit a function. `bail!(X)` is
-/// equivalent to writing:
+/// #[derive(Fail, Debug)]
+/// #[fail(display = "An error occurred.")]
+/// struct CustomFailure;
+/// 
+/// fn example(success: bool) -> Result<(), failure::Error> {
+///     if !success {
+///         throw!(CustomFailure);
+///     }
 ///
-/// ```rust,ignore
-/// return Err(format_err!(X))
+///     Ok(())
+/// }
+///
+/// # fn main() {
+/// #     assert!(example(true).is_ok());
+/// #     assert!(example(false).is_err());
+/// # }
+/// ```
+#[macro_export]
+macro_rules! throw {
+    ($e:expr) => {
+        return Err(::std::convert::Into::into($e));
+    }
+}
+
+/// Early return with an error made from a string.
+/// 
+/// Unlike `throw!`, which expects a type that implements `Fail`, `bail!`
+/// expects to receive standard string interpolation.
+///
+/// ```
+/// #[macro_use] extern crate failure;
+///
+/// fn example(success: bool) -> Result<(), failure::Error> {
+///     if !success {
+///         bail!("Unsuccessful: {}", success);
+///     }
+///
+///     Ok(())
+/// }
+///
+/// # fn main() {
+/// #     assert!(example(true).is_ok());
+/// #     assert!(example(false).is_err());
+/// # }
 /// ```
 #[macro_export]
 macro_rules! bail {
     ($e:expr) => {
-        return Err($crate::err_msg($e));
+        return Err($crate::err_msg::<&'static str>($e));
     };
     ($fmt:expr, $($arg:tt)+) => {
-        return Err($crate::err_msg(format!($fmt, $($arg)+)));
+        return Err($crate::err_msg::<String>(format!($fmt, $($arg)+)));
     };
 }
 
-/// Exits a function early with an `Error` if the condition is not satisfied.
-///
-/// Similar to `assert!`, `ensure!` takes a condition and exits the function
-/// if the condition fails. Unlike `assert!`, `ensure!` returns an `Error`,
-/// it does not panic.
+/// Early return with a string-based error if a condition isn't met.
+/// 
+/// If `bail!` is analogous to `panic!`, `ensure!` is analogous to `assert!`.
+/// 
+/// Like the `bail!` macro, this must take a string, it cannot take an
+/// arbitrary error type. If you want to throw a custom error, you should
+/// use an `if` statement and the `throw!` macro.
 #[macro_export]
 macro_rules! ensure {
     ($cond:expr, $e:expr) => {
@@ -35,17 +82,12 @@ macro_rules! ensure {
     };
 }
 
-/// Constructs an `Error` using the standard string interpolation syntax.
-///
-/// ```rust
-/// #[macro_use] extern crate failure;
-///
-/// fn main() {
-///     let code = 101;
-///     let err = format_err!("Error code: {}", code);
-/// }
-/// ```
+/// Construct an error from a format string without returning it.
+/// 
+/// Unlike `bail!`, this does not terminate the function, it just evaluates
+/// to an `Error`, which you can do other things with.
 #[macro_export]
 macro_rules! format_err {
-    ($($arg:tt)*) => { $crate::err_msg(format!($($arg)*)) }
+    ($e:expr) => { $crate::err_msg::<&'static str>($e) };
+    ($fmt:expr, $($arg:tt)+) => { $crate::err_msg::<String>(format!($fmt, $($arg)+)) };
 }


### PR DESCRIPTION
This makes `bail!` require that it take strings, so that it no longer
has silently different behavior from error-chain.

The `throw!` macro is added to support the alternative use case for
`bail!` that isn't string interpolation.